### PR TITLE
make buildable against latest probe-rs master

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-08-19"
+channel = "nightly"

--- a/teleprobe/Cargo.toml
+++ b/teleprobe/Cargo.toml
@@ -36,12 +36,24 @@ futures = "0.3.28"
 walkdir = "2.4.0"
 orion = "0.17.6"
 hex = "0.4.3"
-
+openssl = { version = "0.10.60", optional = false ,features=["vendored"] }
+#openssl = { version = "0.10.57" }
+#openssl = { version = "0.10.57", optional = true, features=["vendored"]}
 [target.'cfg(not(windows))'.dependencies]
-openssl = { version = "0.10.57", optional = true }
+openssl = { version = "0.10.60", optional = true,features=["vendored"]  }
 
 [build-dependencies]
 git-version = "0.3.5"
+
+[patch.crates-io]
+# make it crosscompile buildable for aarch64 targets / e.g build against openssl 3
+# problem is by default dependancy builds with features default & legacy
+# legacy feature expects openssl 1.0.0 lib on target system which is not available on newer systems
+openssl-sys = { git = "https://github.com/sfackler/rust-openssl" }
+openssl = { git = "https://github.com/sfackler/rust-openssl", optional = false ,features=["vendored"]}
+openssl-src = {git ="https://github.com/alexcrichton/openssl-src-rs", optional = false, features = ["default"]}
+# for riscv esp fixes
+probe-rs = {git = "https://github.com/probe-rs/probe-rs"}
 
 [features]
 default = []

--- a/teleprobe/Cross.toml
+++ b/teleprobe/Cross.toml
@@ -1,0 +1,8 @@
+[target.aarch64-unknown-linux-gnu]
+#pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes libssl-dev libudev-dev"]
+#image = "crossimage"
+#dockerfile = "./crossimage/Dockerfile"
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH"
+]

--- a/teleprobe/src/server.rs
+++ b/teleprobe/src/server.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail};
 use bytes::Bytes;
 use log::{error, info};
 use parking_lot::Mutex;
-use probe_rs::Probe;
+use probe_rs::{Probe, Lister};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::spawn_blocking;
@@ -210,7 +210,9 @@ async fn handle_run(name: String, args: RunArgs, elf: Bytes, cx: Arc<Mutex<Conte
 fn targets(cx: Arc<Mutex<Context>>) -> api::TargetList {
     let targets = cx.lock().config.targets.clone();
     let mut res = Vec::new();
-    let up_probes = Probe::list_all();
+    
+    let probe_lister = Lister::new();
+    let up_probes = probe_lister.list_all();
 
     for target in targets {
         let is_up = !probes_filter(&up_probes, &target.probe).is_empty();


### PR DESCRIPTION
I updated it so far, that it can be build an run against the current probe-rs master. There are lot's of changes and this still needs refactoring, but i hope this will ease the development here further.

Heads-up: I still get a runtime problem with this build on flashing with an esp32c3 currently with the following error:
` ERROR probe_rs::flashing::flasher                            > Failed to verify flash algorithm. Data mismatch at address 0x4038fff8`

For completness here is the relevant debug section. 
```log
 DEBUG probe_rs::flashing::loader                             > committing FlashLoader!
 DEBUG probe_rs::flashing::loader                             > Contents of builder:
 DEBUG probe_rs::flashing::loader                             >     data: 00000000-00005040 (20544 bytes)
 DEBUG probe_rs::flashing::loader                             >     data: 00008000-00008c00 (3072 bytes)
 DEBUG probe_rs::flashing::loader                             >     data: 00010000-000820e0 (467168 bytes)
 DEBUG probe_rs::flashing::loader                             > Flash algorithms:
 DEBUG probe_rs::flashing::loader                             >     algo esp32c3-flashloader: 00000000-01000000 (16777216 bytes)
 DEBUG probe_rs::flashing::loader                             > Regions:
 DEBUG probe_rs::flashing::loader                             >     region: 00000000-01000000 (16777216 bytes)
 DEBUG probe_rs::flashing::loader                             >      -- using algorithm: esp32c3-flashloader
 DEBUG probe_rs::flashing::loader                             >     region: 42000000-43000000 (16777216 bytes)
 DEBUG probe_rs::flashing::loader                             >      -- empty, ignoring!
 DEBUG probe_rs::flashing::loader                             >     region: 3c000000-3d000000 (16777216 bytes)
 DEBUG probe_rs::flashing::loader                             >      -- empty, ignoring!
 DEBUG probe_rs::flashing::loader                             > Flashing ranges for algo: esp32c3-flashloader
 INFO  probe_rs::flashing::flasher                            > Chosen RAM to run the algo: RamRegion { name: None, range: 40380000..403e0000, is_boot_memory: false, cores: ["main"] }
 DEBUG probe_rs::flashing::flash_algorithm                    > The flash algorithm will be configured with 512 bytes of stack
 DEBUG probe_rs::flashing::flasher                            > Initializing the flash algorithm.
 INFO  probe_rs::session                                      > attach_to_core; core_index=0
 DEBUG probe_rs::flashing::flasher                            > Halting core 0
 INFO  probe_rs::core                                         > halt; timeout=100ms
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'dmcontrol' at 0x00000010
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::architecture::riscv                          > Before requesting halt, the Dmcontrol register value was: Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 80000001, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'dmstatus' at 0x00000011
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'dmstatus' at 0x00000011 = Dmstatus { .0: 3a2, impebreak: false, allhavereset: false, anyhavereset: false, allresumeack: false, anyresumeack: false, allnonexistent: false, anynonexistent: false, allunavail: false, anyunavail: false, allrunning: false, anyrunning: false, allhalted: true, anyhalted: true, authenticated: true, authbusy: false, hasresethaltreq: true, confstrptrvalid: false, version: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv                          > Reading CSR 0x7b1
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstractcs: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'command' at 0x00000017 = Command { .0: 2207b1 }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [198, 30, 136, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstracts: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'data0' at 0x00000004
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'data0' at 0x00000004 = Data0 { .0: 40000000 }
 DEBUG probe_rs::flashing::flasher                            > PC = 0x40000000
 DEBUG probe_rs::flashing::flasher                            > Reset and halt
 INFO  probe_rs::core                                         > reset_and_halt; timeout=500ms
 DEBUG probe_rs::architecture::riscv                          > Resetting core, setting hartreset bit
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: a0000001, hartreset: true, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 128, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'dmcontrol' at 0x00000010
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: a0000001, hartreset: true, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::architecture::riscv                          > Clearing hartreset bit
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 80000001, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'dmstatus' at 0x00000011
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'dmstatus' at 0x00000011 = Dmstatus { .0: c03a2, impebreak: false, allhavereset: true, anyhavereset: true, allresumeack: false, anyresumeack: false, allnonexistent: false, anynonexistent: false, allunavail: false, anyunavail: false, allrunning: false, anyrunning: false, allhalted: true, anyhalted: true, authenticated: true, authbusy: false, hasresethaltreq: true, confstrptrvalid: false, version: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 10000001, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv                          > Reading CSR 0x7b0
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstractcs: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'command' at 0x00000017 = Command { .0: 2207b0 }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [194, 30, 136, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstracts: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'data0' at 0x00000004
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'data0' at 0x00000004 = Data0 { .0: c3 }
 DEBUG probe_rs::architecture::riscv                          > Writing CSR 0x7b0
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [14, 195, 2, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstractcs: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'command' at 0x00000017 = Command { .0: 2307b0 }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [194, 30, 140, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstracts: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv                          > Reading CSR 0x7b1
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'dmcontrol' at 0x00000010 = Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstractcs: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'command' at 0x00000017 = Command { .0: 2207b1 }
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [198, 30, 136, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'abstractcs' at 0x00000016
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'abstractcs' at 0x00000016 = Abstractcs { .0: 10000002, progbufsize: 10, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > abstracts: Abstractcs { .0: 268435458, progbufsize: 16, busy: false, cmderr: 0, datacount: 2 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'data0' at 0x00000004
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::architecture::riscv::communication_interface > Read DM register 'data0' at 0x00000004 = Data0 { .0: 40000000 }
 DEBUG probe_rs::flashing::flasher                            > Loading algorithm into RAM; address=1077477368
 DEBUG probe_rs::architecture::riscv::communication_interface > write_32 to 0x4038fff8
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'sbcs' at 0x00000038 = Sbcs { .0: 50000, sbversion: 0, sbbusyerror: false, sbbusy: false, sbreadonaddr: false, sbaccess: 2, sbautoincrement: true, sbreadondata: false, sberror: 0, sbasize: 0, sbaccess128: false, sbaccess64: false, sbaccess32: false, sbaccess16: false, sbaccess8: false }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'sbaddress0' at 0x00000039 = Sbaddress0 { .0: 4038fff8 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'sbcs' at 0x00000038
 DEBUG probe_rs::probe::espusbjtag                            > Preparing 35 writes...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [2, 0, 20, 0, 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [226, 255, 227, 0, 229, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [206, 1, 64, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [206, 1, 64, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 69, 24, 24, 243, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [222, 20, 228, 0, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [14, 20, 21, 28, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [102, 4, 7, 20, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [182, 128, 94, 2, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [30, 255, 159, 3, 242, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [130, 194, 5, 22, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [94, 2, 28, 255, 243, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [158, 3, 2, 82, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [94, 2, 28, 255, 243, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [158, 3, 2, 71, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [102, 148, 7, 20, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [222, 22, 228, 0, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [22, 24, 141, 32, 242, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [22, 27, 200, 2, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 5, 8, 2, 242, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [198, 4, 94, 12, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [30, 255, 159, 1, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [142, 57, 92, 12, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [30, 255, 159, 1, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [142, 53, 76, 220, 241, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [218, 0, 4, 28, 243, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [78, 20, 128, 42, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [10, 2, 186, 26, 242, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [202, 22, 218, 24, 242, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [94, 12, 28, 255, 243, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [158, 1, 12, 50, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [6, 20, 9, 2, 242, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [2, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Sending to chip...
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Got responses! Took 13.712165ms! Processing...
 DEBUG probe_rs::architecture::riscv::communication_interface > read_32 from 0x4038fff8
 DEBUG probe_rs::architecture::riscv::communication_interface > read_32 from 0x4038fff8
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'sbcs' at 0x00000038 = Sbcs { .0: 158000, sbversion: 0, sbbusyerror: false, sbbusy: false, sbreadonaddr: true, sbaccess: 2, sbautoincrement: true, sbreadondata: true, sberror: 0, sbasize: 0, sbaccess128: false, sbaccess64: false, sbaccess32: false, sbaccess16: false, sbaccess8: false }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'sbaddress0' at 0x00000039 = Sbaddress0 { .0: 4038fff8 }
 DEBUG probe_rs::architecture::riscv::communication_interface > Write DM register 'sbcs' at 0x00000038 = Sbcs { .0: 148000, sbversion: 0, sbbusyerror: false, sbbusy: false, sbreadonaddr: true, sbaccess: 2, sbautoincrement: false, sbreadondata: true, sberror: 0, sbasize: 0, sbaccess128: false, sbaccess64: false, sbaccess32: false, sbaccess16: false, sbaccess8: false }
 DEBUG probe_rs::architecture::riscv::communication_interface > Reading DM register 'sbcs' at 0x00000038
 DEBUG probe_rs::probe::espusbjtag                            > Preparing 67 writes...
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [2, 0, 86, 0, 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [226, 255, 227, 0, 229, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [2, 0, 82, 0, 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [1, 0, 0, 0, 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Write DR: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len=41
 DEBUG probe_rs::probe::espusbjtag::protocol                  > JTAG IO! true 
 DEBUG probe_rs::probe::espusbjtag                            > Sending to chip...
 DEBUG probe_rs::probe::espusbjtag::protocol                  > Flushing ...
 DEBUG probe_rs::probe::espusbjtag                            > Got responses! Took 23.197317ms! Processing...
 ERROR probe_rs::flashing::flasher                            > Failed to verify flash algorithm. Data mismatch at address 0x4038fff8
 ERROR probe_rs::flashing::flasher                            > Original instruction: 0x100073
 ERROR probe_rs::flashing::flasher                            > Readback instruction: 0x000000
 ERROR probe_rs::flashing::flasher                            > Original: [100073, 100073, c6061141, 40390537, 7054503, 4501c119, 97a02d, 80e7ffc7, 458170a0, ffc70097, 148080e7, ffc70097, 11c080e7, 4501e519, 403905b7, 88234605, 40b206c5, 80820141, 3178131, 67ffc7, 3170e63, 67ffc7, 77130d63, c7010036, aa00513, 86ae8082, 863685b2, ffc70317, c830067, 80824501, 0]
 ERROR probe_rs::flashing::flasher                            > Readback: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

```